### PR TITLE
Cleanup connections when tracking modules

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -117,15 +117,10 @@ end
 ]=]
 function ModuleLoader:_trackChanges(module: ModuleScript)
 	local existingJanitor = self._janitors[module:GetFullName()]
-	if existingJanitor then
-		existingJanitor:clean()
-		self._janitors[module:GetFullName()] = nil
-	end
+	local janitor = if existingJanitor then existingJanitor else Janitor.new()
 
-	local janitor = Janitor.new()
+	janitor:Cleanup()
 
-	-- TODO: Every time a module is required, these events get hooked up. But
-	-- they only get disconnected when calling ModuleLoader:clear()
 	janitor:Add(module.AncestryChanged:Connect(function()
 		self.loadedModuleChanged:Fire(module)
 	end))

--- a/src/init.spec.lua
+++ b/src/init.spec.lua
@@ -212,7 +212,7 @@ return function()
 			loader:require(modules.ModuleA)
 
 			local hasItems = next(loader._cache) ~= nil
-			expect(hasItems).to.be.ok()
+			expect(hasItems).to.equal(true)
 
 			task.defer(function()
 				modules.ModuleB.Source = 'return "ModuleB Reloaded"'
@@ -220,7 +220,7 @@ return function()
 			loader.loadedModuleChanged:Wait()
 
 			hasItems = next(loader._cache) ~= nil
-			expect(hasItems).never.to.be.ok()
+			expect(hasItems).to.equal(false)
 		end)
 
 		it("should not interfere with other cached modules", function()
@@ -228,7 +228,7 @@ return function()
 			loader:require(modules.ModuleC)
 
 			local hasItems = next(loader._cache) ~= nil
-			expect(hasItems).to.be.ok()
+			expect(hasItems).to.equal(true)
 
 			task.defer(function()
 				modules.ModuleB.Source = 'return "ModuleB Reloaded"'

--- a/src/init.spec.lua
+++ b/src/init.spec.lua
@@ -51,6 +51,30 @@ return function()
 		end)
 	end)
 
+	describe("_trackChanges", function()
+		it("should create a Janitor instance if it doesn't exist", function()
+			local mockModuleInstance = Instance.new("ModuleScript")
+
+			expect(loader._janitors[mockModuleInstance.Name]).never.to.be.ok()
+
+			loader:_trackChanges(mockModuleInstance)
+
+			expect(loader._janitors[mockModuleInstance.Name]).to.be.ok()
+		end)
+
+		it("should reuse the same Janitor instance for future calls", function()
+			local mockModuleInstance = Instance.new("ModuleScript")
+
+			loader:_trackChanges(mockModuleInstance)
+
+			local janitor = loader._janitors[mockModuleInstance.Name]
+
+			loader:_trackChanges(mockModuleInstance)
+
+			expect(loader._janitors[mockModuleInstance.Name]).to.equal(janitor)
+		end)
+	end)
+
 	describe("loadedModuleChanged", function()
 		it("should fire when a required module has its ancestry changed", function()
 			local mockModuleInstance = Instance.new("ModuleScript")


### PR DESCRIPTION
I discovered while working on [flipbook](https://github.com/vocksel/flipbook) that the connections created for a tracked module were not being cleaned up, culminating in a crash if users tried to update a story while viewing it in flipbook

This PR fixes the issue by making sure each module has its own janitor, and that when the same module gets tracked again that the last janitor is cleaned up